### PR TITLE
Add support for registering delegate workers.

### DIFF
--- a/Flower.Tests/WorkRegistryTests.cs
+++ b/Flower.Tests/WorkRegistryTests.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Linq;
 using System.Reactive.Linq;
 using System.Reactive.Subjects;
@@ -345,6 +346,39 @@ namespace Flower.Tests
             Assert.NotEqual(workRegistry.DefaultOptions, work1.Registration.Options);
             Assert.NotEqual(workRegistry.DefaultOptions, work2.Registration.Options);
             Assert.NotEqual(work1.Registration.Options, work2.Registration.Options);
+        }
+
+        [Fact]
+        public void ActionWithNoInputCanBeRegistered()
+        {
+          // Arrange
+          var workRegistry = new WorkRegistry();
+          var trigger = new Subject<int>();
+
+          // Act / Assert
+          Assert.DoesNotThrow(() => workRegistry.Register(trigger, () => { }));
+        }
+
+        [Fact]
+        public void ActionWithInputCanBeRegistered()
+        {
+            // Arrange
+            var workRegistry = new WorkRegistry();
+            var trigger = new Subject<int>();
+
+            // Act / Assert
+            Assert.DoesNotThrow(() => workRegistry.Register(trigger, i => { }));
+        }
+
+        [Fact]
+        public void FuncCanBeRegistered()
+        {
+            // Arrange
+            var workRegistry = new WorkRegistry();
+            var trigger = new Subject<int>();
+
+            // Act / Assert
+            Assert.DoesNotThrow(() => workRegistry.Register(trigger, i => i.ToString(CultureInfo.InvariantCulture)));
         }
     }
 }

--- a/Flower/Flower.csproj
+++ b/Flower/Flower.csproj
@@ -44,6 +44,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="IScope.cs" />
+    <Compile Include="Workers\Worker.cs" />
     <Compile Include="WorkRunners\BackgroundThreadQueueWorkRunner.cs" />
     <Compile Include="Works\IExecutableWork.cs" />
     <Compile Include="Works\IRegisteredWork.cs" />

--- a/Flower/WorkRegistryExtensionMethods.cs
+++ b/Flower/WorkRegistryExtensionMethods.cs
@@ -9,6 +9,33 @@ namespace Flower
         public static IActionWork Register<TInput>(
             this IWorkRegistry workRegistry,
             IObservable<TInput> trigger,
+            Action worker,
+            RegisterOptions options = null)
+        {
+            return workRegistry.Register(trigger, WorkerScope.Instance(new Worker(worker)), options);
+        }
+
+        public static IActionWork<TInput> Register<TInput>(
+            this IWorkRegistry workRegistry,
+            IObservable<TInput> trigger,
+            Action<TInput> worker,
+            RegisterOptions options = null)
+        {
+            return workRegistry.Register(trigger, WorkerScope.Instance(new Worker<TInput>(worker)), options);
+        }
+
+        public static IFuncWork<TInput, TOutput> Register<TInput, TOutput>(
+            this IWorkRegistry workRegistry,
+            IObservable<TInput> trigger,
+            Func<TInput, TOutput> worker,
+            RegisterOptions options = null)
+        {
+            return workRegistry.Register(trigger, WorkerScope.Instance(new Worker<TInput, TOutput>(worker)), options);
+        }
+
+        public static IActionWork Register<TInput>(
+            this IWorkRegistry workRegistry,
+            IObservable<TInput> trigger,
             IWorker worker,
             RegisterOptions options = null)
         {

--- a/Flower/Workers/Worker.cs
+++ b/Flower/Workers/Worker.cs
@@ -1,0 +1,49 @@
+﻿using System;
+
+namespace Flower.Workers
+{
+    internal class Worker : IWorker
+    {
+        private readonly Action worker;
+
+        public Worker(Action worker)
+        {
+            this.worker = worker;
+        }
+
+        public void Execute()
+        {
+            worker();
+        }
+    }
+
+    internal class Worker<TInput> : IWorker<TInput>
+    {
+        private readonly Action<TInput> worker;
+
+        public Worker(Action<TInput> worker)
+        {
+            this.worker = worker;
+        }
+
+        public void Execute(TInput input)
+        {
+            worker(input);
+        }
+    }
+
+    internal class Worker<TInput, TOutput> : IWorker<TInput, TOutput>
+    {
+        private readonly Func<TInput, TOutput> worker;
+
+        public Worker(Func<TInput, TOutput> worker)
+        {
+            this.worker = worker;
+        }
+
+        public TOutput Execute(TInput input)
+        {
+            return worker(input);
+        }
+    }
+}


### PR DESCRIPTION
Add methods for registering `Action`, `Action<TInput>` and `Func<TInput, TOutput>` as workers. Will resolve #12.
